### PR TITLE
Sort by plugin name.

### DIFF
--- a/REPOConfig/ConfigMenu.cs
+++ b/REPOConfig/ConfigMenu.cs
@@ -321,7 +321,7 @@ internal sealed class ConfigMenu
     {
         var repoConfigs = new Dictionary<string, ConfigEntryBase[]>();
         
-        foreach (var plugin in Chainloader.PluginInfos.Values)
+        foreach (var plugin in Chainloader.PluginInfos.Values.OrderBy(p => p.Metadata.Name))
         {
             var configEntries = new List<ConfigEntryBase>();
 


### PR DESCRIPTION
Sorts the list by plugin name. With enough mods, it can be hard to find the right one if it's unsorted.

![image](https://github.com/user-attachments/assets/707014d5-e9a9-4a1b-9914-8766275979d9)